### PR TITLE
fix: prevent inputRef to be overriden

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -719,7 +719,7 @@ class MaterialUiPhoneNumber extends React.Component {
       dropdownClass, autoFormat, disableAreaCodes, isValid, disableCountryCode,
       disableDropdown, enableLongNumbers, countryCodeEditable, onEnterKeyPress,
       isModernBrowser, classes, keys, localization, placeholder, regions, onChange,
-      value,
+      value, inputRef,
       // end placeholder props
       inputClass, error, InputProps,
       ...restProps


### PR DESCRIPTION
fix #12 

An more global solution would be to move the `restProps` spread above the internal prop setting, but it can introduce some breaking changes.