### PR TITLE
fix: la reunion (+262) phone number format

### DIFF
--- a/src/country_data.js
+++ b/src/country_data.js
@@ -1096,7 +1096,7 @@ const rawAllCountries = [
     ['africa'],
     're',
     '262',
-    '+.. . .. .. .. ..',
+    '+... . .. .. .. ..',
   ],
   [
     'Romania',


### PR DESCRIPTION
Hello! 
Firstof, thank you for this lib 🙇🏻 

It looks like the phone numbers format for La Réunion (+262) is invalid:
More details [here](https://www.reunion.fr/organisez/conseils-de-voyage/questions-reponses/le-telephone-a-la-reunion/)

TL&DR:
- Current format: `+26 2 xx xx xx xx`
- Correct format: `+262 x xx xx xx xx`

Hit me if you want more details 👋🏻 